### PR TITLE
fix missing parquet requirements

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -5,3 +5,5 @@ gdown
 opencv-python
 scenedetect
 scikit-image
+pyarrow
+fastparquet


### PR DESCRIPTION
```python
>>> import pandas as pd
>>> d = pd.read_parquet('download/parquet/sakugadataset_train_full.parquet')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/a/SakugaDataset/.venv/lib/python3.10/site-packages/pandas/io/parquet.py", line 651, in read_parquet
    impl = get_engine(engine)
  File "/home/a/SakugaDataset/.venv/lib/python3.10/site-packages/pandas/io/parquet.py", line 67, in get_engine
    raise ImportError(
ImportError: Unable to find a usable engine; tried using: 'pyarrow', 'fastparquet'.
A suitable version of pyarrow or fastparquet is required for parquet support.
Trying to import the above resulted in these errors:
 - Missing optional dependency 'pyarrow'. pyarrow is required for parquet support. Use pip or conda to install pyarrow.
 - Missing optional dependency 'fastparquet'. fastparquet is required for parquet support. Use pip or conda to install fastparquet.
```